### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "nesbot/carbon": "~1.0",
     "guzzlehttp/guzzle": "^6.1"
   },
   "require-dev": {


### PR DESCRIPTION
Carbon is not used anywhere in this package but its inclusion as a dependency prevents using this package with Laravel 6.0. This PR simply removes the Carbon dependency.